### PR TITLE
謎の余白を消しました。

### DIFF
--- a/agrino_HP/agrino.css
+++ b/agrino_HP/agrino.css
@@ -4,7 +4,8 @@ li {
 
 body {
   font-family: 'Aralet','Hiragino Kaku Gothic ProN','メイリオ', sans-serif;
-　margin: 0 -8px;
+	margin: 0px;
+	padding: 0px;
 }
 
 .container {

--- a/agrino_HP/agrino.css
+++ b/agrino_HP/agrino.css
@@ -4,7 +4,7 @@ li {
 
 body {
   font-family: 'Aralet','Hiragino Kaku Gothic ProN','メイリオ', sans-serif;
-　margin: -8px;
+　margin: 0 -8px;
 }
 
 .container {

--- a/agrino_HP/agrino.css
+++ b/agrino_HP/agrino.css
@@ -3,7 +3,7 @@ li {
 }
 
 body {
-  font-family: 'Aralet','Hiragino Kaku Gothic ProN','メイリオ', sans-serif;
+	font-family: 'Aralet','Hiragino Kaku Gothic ProN','メイリオ', sans-serif;
 	margin: 0px;
 	padding: 0px;
 }

--- a/agrino_HP/agrino.css
+++ b/agrino_HP/agrino.css
@@ -4,7 +4,7 @@ li {
 
 body {
   font-family: 'Aralet','Hiragino Kaku Gothic ProN','メイリオ', sans-serif;
-　margin: 0;
+　margin: -8px;
 }
 
 .container {


### PR DESCRIPTION
ブラウザ上で表示したときになぜか

body {
　margin: 8px;
}

が適用されていたのを修正して、なぞの余白を消しました。

詳細はコミットのコメントを参照してください。